### PR TITLE
Adds placeholder to email field and tweak styles

### DIFF
--- a/src/components/FooterSection.vue
+++ b/src/components/FooterSection.vue
@@ -70,7 +70,7 @@
                             <h3>Subscribe</h3>
                             <p>Stay updated!</p>
                             <div>
-                                <input v-validate="'required|email'" name="email" type="text" id="maintext">
+                                <input v-validate="'required|email'" name="email" type="text" id="maintext" placeholder="Email">
                             </div>
                             <div>
                                 <p id="thanks">{{message}}</p>
@@ -193,6 +193,7 @@ button:hover {
   height: 40px;
   margin-bottom: 5%;
   color: white;
+  padding-left: 6px;
 }
 
 #thanks {


### PR DESCRIPTION
- Adds a placeholder to the email field
- Adds a bit of left padding to it

### Screenshots

**Before**

![image](https://user-images.githubusercontent.com/7039523/51805790-96cfde00-223f-11e9-8870-b13ee7ecfa0a.png)


**After**

![image](https://user-images.githubusercontent.com/7039523/51805802-b6ff9d00-223f-11e9-9f0f-793c08d6a3b3.png)




The current placeholder is 'Email'. We could make it 'john@doe.com' or something similar. What do you think?
